### PR TITLE
`ticket_data` is not always a list

### DIFF
--- a/plugins/modules/zammad_ticket.py
+++ b/plugins/modules/zammad_ticket.py
@@ -415,7 +415,7 @@ def run_module():
             result.update(
                 {
                     "changed": True,
-                    "ticket_id": ticket_id
+                    "ticket_id": ticket_id,
                     "status_code": status_code,
                     "message": "Ticket created successfully.",
                 }

--- a/plugins/modules/zammad_ticket.py
+++ b/plugins/modules/zammad_ticket.py
@@ -408,10 +408,14 @@ def run_module():
             if module.params["sender"]:
                 ticket_data["article"]["sender"] = module.params["sender"]
             ticket_data, status_code = create_ticket(module, zammad_access, ticket_data)
+            if isinstance(ticket_data, list):
+                ticket_id = ticket_data.get[0]("id")
+            else:
+                ticket_id = ticket_data["id"]
             result.update(
                 {
                     "changed": True,
-                    "ticket_id": ticket_data.get("id"),
+                    "ticket_id": ticket_id
                     "status_code": status_code,
                     "message": "Ticket created successfully.",
                 }


### PR DESCRIPTION
Running the `scaleuptechnologies.zammad.zammad_ticket` module resulted in an error, because the `ticket_data` did not contain a list, but just a dictionary.

Zammad version: 7.0.0-1773148656.3c95b7da.bookworm