### PR TITLE
feat(zammad_ticket): add cc parameter for article recipients

### DIFF
--- a/changelogs/fragments/zammad_ticket_cc.yaml
+++ b/changelogs/fragments/zammad_ticket_cc.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - zammad_ticket - add optional ``cc`` parameter to pass CC recipients in the article (https://github.com/scaleup-technologies/ansible-zammad/pull/9).

--- a/plugins/modules/zammad_ticket.py
+++ b/plugins/modules/zammad_ticket.py
@@ -122,6 +122,11 @@ options:
     type: str
     default: 'text/plain'
     choices: ['text/html', 'text/plain']
+  cc:
+    description:
+      - Comma-separated list of CC recipients for the ticket's article (e.g., 'a@example.com, b@example.com').
+    required: false
+    type: str
   custom_fields:
     description:
       - Custom objects that can be passed to the Zammad API to extend the functionality.
@@ -216,6 +221,7 @@ def create_article(
     internal: bool,
     content_type: str,
     sender: str,
+    cc: str = None,
 ):
     data = {
         "ticket_id": ticket_id,
@@ -226,6 +232,8 @@ def create_article(
         "content_type": content_type,
         "sender": sender,
     }
+    if cc:
+        data["cc"] = cc
     return make_request(module, "POST", zammad_access, data, endpoint="ticket_articles")
 
 
@@ -285,6 +293,7 @@ def run_module():
         sender=dict(
             type="str", choices=["Agent", "Customer", "System"], required=False, default="Agent"
         ),
+        cc=dict(type="str", required=False),
     )
 
     module_args = {**module_args}
@@ -346,6 +355,8 @@ def run_module():
                     }
                     if module.params["sender"]:
                         new_ticket_data["article"]["sender"] = module.params["sender"]
+                    if module.params["cc"]:
+                        new_ticket_data["article"]["cc"] = module.params["cc"]
                 ticket_data, status_code = update_ticket(
                     module, zammad_access, module.params["ticket_id"], new_ticket_data
                 )
@@ -359,6 +370,7 @@ def run_module():
                     module.params["internal"],
                     module.params["content_type"],
                     module.params["sender"],
+                    module.params["cc"],
                 )
             if ticket_changes:
                 result.update(
@@ -407,6 +419,8 @@ def run_module():
             }
             if module.params["sender"]:
                 ticket_data["article"]["sender"] = module.params["sender"]
+            if module.params["cc"]:
+                ticket_data["article"]["cc"] = module.params["cc"]
             ticket_data, status_code = create_ticket(module, zammad_access, ticket_data)
             result.update(
                 {

--- a/tests/unit/plugins/modules/test_zammad_ticket.py
+++ b/tests/unit/plugins/modules/test_zammad_ticket.py
@@ -417,3 +417,113 @@ def test_update_ticket_new_article():
             "type": "note",
         }
         assert json.loads(third_call_args[1]["data"]) == expected_data
+
+
+def test_create_new_ticket_with_cc():
+    fake_response_1 = MagicMock()
+    fake_response_1.read.return_value = b'{"id": 99}'
+    fake_info_1 = {"status": 200, "msg": "OK"}
+
+    with patch(
+        FETCH_URL_METHOD,
+        side_effect=[(fake_response_1, fake_info_1)],
+    ) as mock_fetch_url:
+        set_module_args(
+            {
+                "zammad_access": {
+                    "zammad_url": "https://example.com",
+                    "api_user": "user",
+                    "api_secret": "secret",
+                },
+                "title": "Internet Outage",
+                "group": "Support",
+                "customer": "customer@example.com",
+                "subject": "Internet is down",
+                "body": "The internet is not working since this morning.",
+                "internal": "false",
+                "state": "open",
+                "cc": "a@example.com, b@example.com",
+            }
+        )
+        try:
+            zammad_ticket.main()
+        except AnsibleExitJson as e:
+            result = e.args[0]
+            assert result["changed"] is True
+        assert mock_fetch_url.call_count == 1
+
+        first_call_args = mock_fetch_url.call_args_list[0]
+        assert first_call_args[0][1] == "https://example.com/api/v1/tickets"
+        assert first_call_args[1]["method"] == "POST"
+        expected_data = {
+            "customer": "customer@example.com",
+            "title": "Internet Outage",
+            "group": "Support",
+            "state": "open",
+            "article": {
+                "subject": "Internet is down",
+                "body": "The internet is not working since this morning.",
+                "type": "note",
+                "internal": "false",
+                "content_type": "text/plain",
+                "sender": "Agent",
+                "cc": "a@example.com, b@example.com",
+            },
+        }
+        assert json.loads(first_call_args[1]["data"]) == expected_data
+
+
+def test_update_ticket_new_article_with_cc():
+    fake_response_1 = MagicMock()
+    fake_response_1.read.return_value = read_fixture_file("ticket42.json")
+    fake_info_1 = {"status": 200, "msg": "OK"}
+
+    fake_response_2 = MagicMock()
+    fake_response_2.read.return_value = read_fixture_file("articles42.json")
+    fake_info_2 = {"status": 200, "msg": "OK"}
+
+    fake_response_3 = MagicMock()
+    fake_response_3.read.return_value = '{"id": 43}'
+    fake_info_3 = {"status": 201, "msg": "OK"}
+
+    with patch(
+        FETCH_URL_METHOD,
+        side_effect=[
+            (fake_response_1, fake_info_1),
+            (fake_response_2, fake_info_2),
+            (fake_response_3, fake_info_3),
+        ],
+    ) as mock_fetch_url:
+        set_module_args(
+            {
+                "zammad_access": {
+                    "zammad_url": "https://example.com",
+                    "api_token": "my_api_token",
+                },
+                "ticket_id": 42,
+                "subject": "Internet is down",
+                "body": "The internet is not working since this morning.",
+                "cc": "a@example.com, b@example.com",
+            }
+        )
+        try:
+            zammad_ticket.main()
+        except AnsibleExitJson as e:
+            result = e.args[0]
+            assert result["changed"] is True
+        assert mock_fetch_url.call_count == 3
+
+        third_call_args = mock_fetch_url.call_args_list[2]
+        assert third_call_args[0][1] == "https://example.com/api/v1/ticket_articles"
+        assert third_call_args[1]["method"] == "POST"
+        expected_data = {
+            "body": "The internet is not working since this morning.",
+            "cc": "a@example.com, b@example.com",
+            "content_type": "text/plain",
+            "internal": "false",
+            "sender": "Agent",
+            "subject": "Internet is down",
+            "ticket_id": 42,
+            "type": "note",
+        }
+        assert json.loads(third_call_args[1]["data"]) == expected_data


### PR DESCRIPTION
Adds an optional `cc` parameter that is passed as `article.cc` when creating or updating a ticket, enabling multiple recipients without requiring a direct API call.