### PR TITLE
fix(zammad_ticket_idoit): use correct idoit integration endpoint

### DIFF
--- a/changelogs/fragments/zammad_ticket_idoit_endpoint.yaml
+++ b/changelogs/fragments/zammad_ticket_idoit_endpoint.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - zammad_ticket_idoit - fix HTTP 422 errors by using the correct idoit integration endpoint ``POST /api/v1/integration/idoit_ticket_update`` instead of ``PUT /api/v1/tickets/{id}`` (https://github.com/scaleup-technologies/ansible-zammad/pull/10).

--- a/changelogs/fragments/zammad_ticket_idoit_endpoint.yaml
+++ b/changelogs/fragments/zammad_ticket_idoit_endpoint.yaml
@@ -1,3 +1,5 @@
 ---
 bugfixes:
-  - zammad_ticket_idoit - fix HTTP 422 errors by using the correct idoit integration endpoint ``POST /api/v1/integration/idoit_ticket_update`` instead of ``PUT /api/v1/tickets/{id}`` (https://github.com/scaleup-technologies/ansible-zammad/pull/10).
+  - zammad_ticket_idoit - fix HTTP 422 errors by using the correct endpoint
+    ``POST /api/v1/integration/idoit_ticket_update`` instead of ``PUT /api/v1/tickets/{id}``
+    (https://github.com/scaleup-technologies/ansible-zammad/pull/10).

--- a/plugins/modules/zammad_ticket_idoit.py
+++ b/plugins/modules/zammad_ticket_idoit.py
@@ -110,8 +110,8 @@ def get_ticket(module, zammad_access, ticket_id):
 
 
 def change_idoit_object(module, zammad_access, ticket_id, object_ids):
-    data = {"preferences": {"idoit": {"object_ids": object_ids}}}
-    return make_request(module, "PUT", zammad_access, data, ticket_id)
+    data = {"ticket_id": ticket_id, "object_ids": object_ids}
+    return make_request(module, "POST", zammad_access, data, endpoint="integration/idoit_ticket_update")
 
 
 def run_module():

--- a/tests/unit/plugins/modules/test_zammad_ticket_idoit.py
+++ b/tests/unit/plugins/modules/test_zammad_ticket_idoit.py
@@ -103,9 +103,9 @@ def test_module_key_does_not_exist_before():
 
         # Überprüfen der übergebenen Parameter beim zweiten Aufruf
         second_call_args = mock_fetch_url.call_args_list[1]
-        assert second_call_args[0][1] == "https://example.com/api/v1/tickets/1"
-        assert second_call_args[1]["method"] == "PUT"
-        assert second_call_args[1]["data"] == '{"preferences": {"idoit": {"object_ids": ["123"]}}}'
+        assert second_call_args[0][1] == "https://example.com/api/v1/integration/idoit_ticket_update"
+        assert second_call_args[1]["method"] == "POST"
+        assert json.loads(second_call_args[1]["data"]) == {"ticket_id": 1, "object_ids": ["123"]}
 
 
 def test_module_no_changes():
@@ -186,6 +186,6 @@ def test_module_success():
 
         # Überprüfen der übergebenen Parameter beim zweiten Aufruf
         second_call_args = mock_fetch_url.call_args_list[1]
-        assert second_call_args[0][1] == "https://example.com/api/v1/tickets/1"
-        assert second_call_args[1]["method"] == "PUT"
-        assert second_call_args[1]["data"] == '{"preferences": {"idoit": {"object_ids": ["123"]}}}'
+        assert second_call_args[0][1] == "https://example.com/api/v1/integration/idoit_ticket_update"
+        assert second_call_args[1]["method"] == "POST"
+        assert json.loads(second_call_args[1]["data"]) == {"ticket_id": 1, "object_ids": ["123"]}


### PR DESCRIPTION
Replace PUT /api/v1/tickets/{id} with POST /api/v1/integration/idoit_ticket_update to avoid HTTP 422 errors when tickets have mandatory fields that Zammad validates on every full ticket PUT.