### PR TITLE
fix(zammad_ticket): custom_fields werden beim Erstellen eines Tickets…

### DIFF
--- a/changelogs/fragments/zammad_ticket_custom_fields_create.yaml
+++ b/changelogs/fragments/zammad_ticket_custom_fields_create.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - zammad_ticket - fix custom_fields being silently ignored when creating a ticket (https://github.com/scaleup-technologies/ansible-zammad/pull/11).

--- a/plugins/modules/zammad_ticket.py
+++ b/plugins/modules/zammad_ticket.py
@@ -321,13 +321,14 @@ def run_module():
             new_ticket_data = {}
             for key in ticket_keys:
                 if key in module.params and module.params[key] is not None:
-                    if key in module.params.keys():
-                        new_value = module.params[key]
-                    else:
-                        new_value = module.params["custom_fields"][key]
-                    if key not in ticket_data or new_value != ticket_data[key]:
-                        ticket_changes = True
-                        new_ticket_data[key] = new_value
+                    new_value = module.params[key]
+                elif key in module.params.get("custom_fields", {}):
+                    new_value = module.params["custom_fields"][key]
+                else:
+                    continue
+                if key not in ticket_data or new_value != ticket_data[key]:
+                    ticket_changes = True
+                    new_ticket_data[key] = new_value
             # We create a new article if the subject or body has changed
             for key in ["subject", "body"]:
                 if key in module.params and module.params[key] is not None:
@@ -398,6 +399,8 @@ def run_module():
             for key in ticket_keys:
                 if key in module.params and module.params[key] is not None:
                     ticket_data[key] = module.params[key]
+                elif key in module.params.get("custom_fields", {}):
+                    ticket_data[key] = module.params["custom_fields"][key]
             ticket_data["article"] = {
                 "subject": module.params["subject"],
                 "body": module.params["body"],

--- a/tests/unit/plugins/modules/test_zammad_ticket.py
+++ b/tests/unit/plugins/modules/test_zammad_ticket.py
@@ -354,6 +354,50 @@ def test_update_ticket_new_article_and_priority():
         assert json.loads(third_call_args[1]["data"]) == expected_data
 
 
+def test_create_new_ticket_with_custom_fields():
+    fake_response_1 = MagicMock()
+    fake_response_1.read.return_value = b'{"id": 43}'
+    fake_info_1 = {"status": 200, "msg": "OK"}
+
+    with patch(
+        FETCH_URL_METHOD,
+        side_effect=[(fake_response_1, fake_info_1)],
+    ) as mock_fetch_url:
+        set_module_args(
+            {
+                "zammad_access": {
+                    "zammad_url": "https://example.com",
+                    "api_user": "user",
+                    "api_secret": "secret",
+                },
+                "title": "Internet Outage",
+                "group": "Support",
+                "customer": "customer@example.com",
+                "subject": "Internet is down",
+                "body": "The internet is not working since this morning.",
+                "internal": "false",
+                "state": "open",
+                "custom_fields": {
+                    "contract_number": "C-12345",
+                    "affected_site": "Berlin",
+                },
+            }
+        )
+        try:
+            zammad_ticket.main()
+        except AnsibleExitJson as e:
+            result = e.args[0]
+            assert result["changed"] is True
+        assert mock_fetch_url.call_count == 1
+
+        first_call_args = mock_fetch_url.call_args_list[0]
+        assert first_call_args[0][1] == "https://example.com/api/v1/tickets"
+        assert first_call_args[1]["method"] == "POST"
+        body = json.loads(first_call_args[1]["data"])
+        assert body["contract_number"] == "C-12345"
+        assert body["affected_site"] == "Berlin"
+
+
 def test_update_ticket_new_article():
 
     fake_response_1 = MagicMock()


### PR DESCRIPTION
… nicht ignoriert

Im Create-Pfad fehlte der Fallback auf module.params["custom_fields"], sodass Custom Fields stillschweigend ignoriert wurden. Außerdem war im Update-Pfad die innere else-Branch tot (nie erreichbar) — auch dort wurde der Fallback korrigiert.