### PR TITLE
fix: skip sanity-py3.12-devel

### DIFF
--- a/tox-ansible.ini
+++ b/tox-ansible.ini
@@ -8,3 +8,4 @@ skip =
     2.11
     2.12
     2.13
+    sanity-py3.12-devel


### PR DESCRIPTION
 ansible-core devel requires Python 3.13+